### PR TITLE
Fix default CTRL+P action to not always use git files only

### DIFF
--- a/home-manager-modules/nixvim.nix
+++ b/home-manager-modules/nixvim.nix
@@ -268,7 +268,7 @@ in
         enable = true;
         keymaps = {
           "<C-p>" = {
-            action = "git_files";
+            action = "find_files";
           };
           "<leader>ps" = {
             action = "live_grep";


### PR DESCRIPTION
Fixes #5

Update the default CTRL+P action to not always use git files only.

* Change the keymap for `<C-p>` in `home-manager-modules/nixvim.nix` to use `find_files` instead of `git_files`
* This change ensures that the default action for CTRL+P searches for files in the current directory, regardless of whether it is a git repository

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fjij/nix-configs/pull/8?shareId=42528d45-b87c-40de-bab8-03f148554689).