### PR TITLE
Add weekly flake updates

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,32 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Runs every Sunday at midnight
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Update flake.lock
+        run: nix flake update
+
+      - name: Commit changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -am 'Update flake.lock'
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update flake.lock
+          title: Update flake.lock
+          body: This PR updates the flake.lock file to the latest versions of dependencies.


### PR DESCRIPTION
Fixes #10

Add a new GitHub Actions workflow to update `flake.lock` weekly.

* **New Workflow**: Add `.github/workflows/update-flake-lock.yml` to handle weekly updates.
  * Schedule the workflow to run every Sunday at midnight using a cron job.
  * Checkout the repository, set up Nix, and update the `flake.lock` file.
  * Commit the changes with a standard commit message.
  * Create a pull request using the `peter-evans/create-pull-request` action.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fjij/nix-configs/pull/11?shareId=5d57fee2-01a9-420d-8ae2-4521a6645cae).