### PR TITLE
Use `nix.optimise.automatic`

### DIFF
--- a/darwin-modules/base-darwin.nix
+++ b/darwin-modules/base-darwin.nix
@@ -26,6 +26,7 @@ in
     # Auto upgrade nix package and the daemon service.
     services.nix-daemon.enable = true;
     nix = {
+      optimise.automatic = true;
       package = pkgs.nix;
       gc = {
         automatic = true;
@@ -34,7 +35,6 @@ in
       };
       settings = {
         experimental-features = "nix-command flakes";
-        auto-optimise-store = true;
         trusted-users = [
           "root"
           "@admin"


### PR DESCRIPTION
Use `nix.optimise.automatic` instead of `nix.settings.auto-optimise-store`, since the latter is can lead to Nix store corruption on MacOS.

See https://github.com/NixOS/nix/issues/7273 for more info.