### PR TITLE
Rename Nixvim diagnostics to diagnostic.settings

### DIFF
--- a/home-manager-modules/nixvim.nix
+++ b/home-manager-modules/nixvim.nix
@@ -100,7 +100,7 @@ in
       '';
 
       # Only show LSP messages for current line
-      diagnostics = {
+      diagnostic.settings = {
         virtual_lines.only_current_line = true;
         virtual_text = false;
       };


### PR DESCRIPTION
I got this warning when deploying the latest update:

```text
warning: The option `diagnostics' defined in `/nix/store/sm4n10r0jjmxc25bs54ivhzwbpc999bi-source/home-manager-modules/nixvim.nix' has been renamed to `diagnostic.settings'.
```